### PR TITLE
docs: add contributor guidelines and update Kaminashi role

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,36 @@
+# Repository Guidelines
+
+## Project Structure & Module Organization
+- `src/` contains the React + TypeScript application code; entry point is `src/main.tsx`.
+- `src/components/` holds UI sections (Home, Work, Education, etc.).
+- `src/data/` stores content in YAML files (e.g., `general_info.yml`, `projects.yml`).
+- `src/assets/`, `public/`, and `images/` contain static assets.
+- `docs/` is the GitHub Pages build output (generated from `dist/`).
+
+## Build, Test, and Development Commands
+- `pnpm dev` starts the Vite dev server.
+- `pnpm build` builds production assets, then copies `dist/` to `docs/` for Pages.
+- `pnpm preview` serves the production build locally.
+- `pnpm lint` runs ESLint on `src/`.
+- `pnpm format` checks Prettier formatting.
+- `pnpm types:check` runs TypeScript checks without emitting files.
+- `pnpm validate` runs lint, format, and type checks together.
+
+## Coding Style & Naming Conventions
+- TypeScript + React with JSX; prefer functional components.
+- Formatting uses Prettier (`printWidth: 100`, single quotes including JSX). Indentation follows Prettier defaults.
+- Linting via ESLint (`eslint.config.mjs`) with XO/MUI rules.
+- File naming: PascalCase for components (`Home.tsx`), lowercase with underscores for YAML data (`work_experience.yml`).
+
+## Testing Guidelines
+- No automated test framework is currently configured. If adding tests, document the runner and naming (e.g., `*.test.tsx`) in this file.
+- For changes, run `pnpm validate` and manually verify the UI in `pnpm dev` or `pnpm preview`.
+
+## Commit & Pull Request Guidelines
+- Commit messages generally follow a Conventional Commit style (e.g., `feat: add mise configuration`). Keep them short and imperative.
+- PRs should include a brief summary and, for UI changes, before/after screenshots or GIFs.
+- Link relevant issues if they exist; note any manual test steps performed.
+
+## Configuration Notes
+- Key config files: `vite.config.ts`, `tsconfig.json`, `eslint.config.mjs`, `.prettierrc.cjs`.
+- Content updates typically go through YAML in `src/data/`; components render these files at runtime.

--- a/src/data/work_experience.yml
+++ b/src/data/work_experience.yml
@@ -1,8 +1,18 @@
 experience:
+  - position: "AI Enabling Engineer"
+    company: "Kaminashi Inc."
+    location: "Tokyo, Japan"
+    period: "May 2025 - Current"
+    details:
+      - "Partner with business teams to find high-impact AI use cases and ship prototypes that boost productivity"
+      - "Deliver AI-assisted workflows with guardrails, connecting LLM tooling to internal systems safely"
+      - "Coach non-engineering staff on prompt patterns and reusable templates, accelerating team self-service"
+      - "Measure adoption and iterate with business leads to prioritize the next AI enablement backlog"
+
   - position: "Fullstack Engineer - Go/TypeScript"
     company: "Kaminashi Inc."
     location: "Tokyo, Japan"
-    period: "May 2023 - Current"
+    period: "May 2023 - April 2025"
     details:
       - "Led the design, infrastructure setup, and backend development for new product launches"
       - "Guided the service team by articulating user value and identifying minimum requirements, minimizing time to delivery"


### PR DESCRIPTION
## Summary
- Add new "GTM Engineer | AI Engineer" role at Kaminashi (May 2025 - Current) with AI enablement responsibilities
- Update previous Fullstack Engineer role period to May 2023 - April 2025
- Add `AGENTS.md` with repository guidelines (project structure, build commands, coding style, commit conventions)
- Rebuild docs for deployment

## Test plan
- [ ] Verify site renders correctly at the deployed GitHub Pages URL
- [ ] Confirm the new role and updated period display properly in the Work Experience section

🤖 Generated with [Claude Code](https://claude.com/claude-code)