### PR TITLE
feat: add HTML resume for FDE application

### DIFF
--- a/docs/resume.html
+++ b/docs/resume.html
@@ -1,0 +1,419 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Atsuhiro Uchida – Resume</title>
+  <style>
+    *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+    body {
+      font-family: 'Helvetica Neue', Arial, sans-serif;
+      font-size: 9pt;
+      color: #1a1a1a;
+      background: #fff;
+      line-height: 1.4;
+    }
+
+    .page {
+      width: 210mm;
+      min-height: 297mm;
+      margin: 0 auto;
+      display: flex;
+    }
+
+    /* ── Sidebar ── */
+    .sidebar {
+      width: 58mm;
+      background: #1e3a5f;
+      color: #e8eef5;
+      padding: 10mm 6mm;
+      flex-shrink: 0;
+    }
+
+    .sidebar h1 {
+      font-size: 14pt;
+      font-weight: 700;
+      color: #fff;
+      line-height: 1.2;
+      margin-bottom: 2mm;
+    }
+
+    .sidebar .subtitle {
+      font-size: 8pt;
+      color: #a8c4e0;
+      margin-bottom: 6mm;
+      line-height: 1.3;
+    }
+
+    .sidebar-section {
+      margin-bottom: 5mm;
+    }
+
+    .sidebar-section h2 {
+      font-size: 7.5pt;
+      font-weight: 700;
+      text-transform: uppercase;
+      letter-spacing: 0.08em;
+      color: #a8c4e0;
+      border-bottom: 1px solid #2e5480;
+      padding-bottom: 1mm;
+      margin-bottom: 2.5mm;
+    }
+
+    .contact-item {
+      font-size: 7.5pt;
+      color: #d0e4f5;
+      margin-bottom: 1.5mm;
+      word-break: break-all;
+    }
+
+    .contact-item a {
+      color: #d0e4f5;
+      text-decoration: none;
+    }
+
+    .skill-group {
+      margin-bottom: 3mm;
+    }
+
+    .skill-group-label {
+      font-size: 7pt;
+      font-weight: 700;
+      color: #a8c4e0;
+      margin-bottom: 1mm;
+    }
+
+    .skill-tags {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 1.5mm;
+    }
+
+    .skill-tag {
+      background: #2e5480;
+      color: #d0e4f5;
+      font-size: 6.5pt;
+      padding: 0.8mm 2mm;
+      border-radius: 2px;
+    }
+
+    .community-item {
+      font-size: 7.5pt;
+      color: #d0e4f5;
+      margin-bottom: 1mm;
+    }
+
+    /* ── Main ── */
+    .main {
+      flex: 1;
+      padding: 10mm 8mm 8mm 8mm;
+    }
+
+    .section {
+      margin-bottom: 5mm;
+    }
+
+    .section-title {
+      font-size: 9pt;
+      font-weight: 700;
+      text-transform: uppercase;
+      letter-spacing: 0.1em;
+      color: #1e3a5f;
+      border-bottom: 1.5px solid #1e3a5f;
+      padding-bottom: 1mm;
+      margin-bottom: 3mm;
+    }
+
+    .job {
+      margin-bottom: 4mm;
+    }
+
+    .job-header {
+      display: flex;
+      justify-content: space-between;
+      align-items: baseline;
+      margin-bottom: 0.5mm;
+    }
+
+    .job-title {
+      font-size: 9pt;
+      font-weight: 700;
+      color: #1a1a1a;
+    }
+
+    .job-period {
+      font-size: 7.5pt;
+      color: #666;
+      white-space: nowrap;
+      margin-left: 3mm;
+    }
+
+    .job-company {
+      font-size: 8pt;
+      color: #1e3a5f;
+      font-weight: 600;
+      margin-bottom: 1.5mm;
+    }
+
+    .job ul {
+      padding-left: 3.5mm;
+      list-style: none;
+    }
+
+    .job ul li {
+      font-size: 8pt;
+      color: #333;
+      margin-bottom: 1mm;
+      line-height: 1.35;
+      position: relative;
+      padding-left: 3mm;
+    }
+
+    .job ul li::before {
+      content: '▸';
+      position: absolute;
+      left: 0;
+      color: #1e3a5f;
+      font-size: 7pt;
+      top: 0.5px;
+    }
+
+    .edu-item {
+      margin-bottom: 2.5mm;
+    }
+
+    .edu-header {
+      display: flex;
+      justify-content: space-between;
+      align-items: baseline;
+    }
+
+    .edu-degree {
+      font-size: 8.5pt;
+      font-weight: 700;
+      color: #1a1a1a;
+    }
+
+    .edu-period {
+      font-size: 7.5pt;
+      color: #666;
+    }
+
+    .edu-institution {
+      font-size: 8pt;
+      color: #1e3a5f;
+      font-weight: 600;
+    }
+
+    .edu-detail {
+      font-size: 7.5pt;
+      color: #555;
+      margin-top: 0.8mm;
+    }
+
+    .interns {
+      display: flex;
+      gap: 4mm;
+    }
+
+    .intern-item {
+      flex: 1;
+    }
+
+    .intern-title {
+      font-size: 8pt;
+      font-weight: 700;
+      color: #1a1a1a;
+    }
+
+    .intern-company {
+      font-size: 7.5pt;
+      color: #1e3a5f;
+      font-weight: 600;
+    }
+
+    .intern-period {
+      font-size: 7pt;
+      color: #666;
+    }
+
+    .intern-detail {
+      font-size: 7.5pt;
+      color: #333;
+      margin-top: 1mm;
+      line-height: 1.35;
+    }
+
+    @media print {
+      body { margin: 0; }
+      .page {
+        width: 210mm;
+        min-height: 297mm;
+        margin: 0;
+      }
+      @page {
+        size: A4;
+        margin: 0;
+      }
+    }
+  </style>
+</head>
+<body>
+<div class="page">
+
+  <!-- ── Sidebar ── -->
+  <div class="sidebar">
+    <h1>Atsuhiro<br>Uchida</h1>
+    <div class="subtitle">AI Engineer /<br>Software Engineer</div>
+
+    <div class="sidebar-section">
+      <h2>Contact</h2>
+      <div class="contact-item">atsuhiro.uchida.a2@gmail.com</div>
+      <div class="contact-item"><a href="https://linkedin.com/in/atsuhiro-uchida">linkedin.com/in/atsuhiro-uchida</a></div>
+      <div class="contact-item"><a href="https://github.com/timtoronto634">github.com/timtoronto634</a></div>
+      <div class="contact-item"><a href="https://timtoronto634.github.io">timtoronto634.github.io</a></div>
+    </div>
+
+    <div class="sidebar-section">
+      <h2>Skills</h2>
+      <div class="skill-group">
+        <div class="skill-group-label">Languages</div>
+        <div class="skill-tags">
+          <span class="skill-tag">Python</span>
+          <span class="skill-tag">Go</span>
+          <span class="skill-tag">TypeScript</span>
+          <span class="skill-tag">Ruby</span>
+        </div>
+      </div>
+      <div class="skill-group">
+        <div class="skill-group-label">AI / ML</div>
+        <div class="skill-tags">
+          <span class="skill-tag">Gemini API</span>
+          <span class="skill-tag">AWS Bedrock</span>
+          <span class="skill-tag">Prompt Eng.</span>
+          <span class="skill-tag">PyTorch</span>
+        </div>
+      </div>
+      <div class="skill-group">
+        <div class="skill-group-label">Cloud & Infra</div>
+        <div class="skill-tags">
+          <span class="skill-tag">GCP</span>
+          <span class="skill-tag">AWS</span>
+          <span class="skill-tag">Docker</span>
+          <span class="skill-tag">Terraform</span>
+          <span class="skill-tag">Kubernetes</span>
+          <span class="skill-tag">CI/CD</span>
+        </div>
+      </div>
+      <div class="skill-group">
+        <div class="skill-group-label">Frameworks</div>
+        <div class="skill-tags">
+          <span class="skill-tag">Rails</span>
+          <span class="skill-tag">React</span>
+          <span class="skill-tag">Django</span>
+          <span class="skill-tag">Next.js</span>
+        </div>
+      </div>
+    </div>
+
+    <div class="sidebar-section">
+      <h2>Community</h2>
+      <div class="community-item">AWS Community Builder<br><span style="font-size:7pt;color:#a8c4e0">Mar 2025 – Present</span></div>
+      <div class="community-item" style="margin-top:2mm">AWS re:Invent 2023 &amp; 2024<br><span style="font-size:7pt;color:#a8c4e0">Las Vegas</span></div>
+      <div class="community-item" style="margin-top:2mm">Go Conference Japan 2024<br><span style="font-size:7pt;color:#a8c4e0">Volunteer Staff</span></div>
+    </div>
+
+    <div class="sidebar-section">
+      <h2>Languages</h2>
+      <div class="community-item">Japanese — Native</div>
+      <div class="community-item">English — Professional</div>
+    </div>
+  </div>
+
+  <!-- ── Main ── -->
+  <div class="main">
+
+    <div class="section">
+      <div class="section-title">Work Experience</div>
+
+      <div class="job">
+        <div class="job-header">
+          <div class="job-title">GTM Engineer | AI Engineer</div>
+          <div class="job-period">May 2025 – Present</div>
+        </div>
+        <div class="job-company">Kaminashi Inc. · Tokyo, Japan</div>
+        <ul>
+          <li>Built an AI pipeline integrating HubSpot CRM data with AWS Bedrock LLM API, cutting sales team promotion prep time by 60% and reducing proposal creation from 3 hours to 30 minutes</li>
+          <li>Rolled out Gemini-based AI workflows from an 8-person pilot to a 30-person sales org, delivering structured prompt templates and guardrails that enabled non-technical staff to self-serve without engineering support</li>
+          <li>Identified high-impact AI use cases through stakeholder interviews, shipped iterative prototypes, and coached 30+ business users on AI-assisted workflows</li>
+        </ul>
+      </div>
+
+      <div class="job">
+        <div class="job-header">
+          <div class="job-title">Fullstack Engineer — Go / TypeScript</div>
+          <div class="job-period">May 2023 – Apr 2025</div>
+        </div>
+        <div class="job-company">Kaminashi Inc. · Tokyo, Japan</div>
+        <ul>
+          <li>Led design, infrastructure setup, and backend development for new product launches; articulated user value to reduce time-to-delivery</li>
+          <li>Automated CI/CD pipelines and implemented OIDC authentication flows (client & resource-server), resolving key delivery bottlenecks</li>
+        </ul>
+      </div>
+
+      <div class="job">
+        <div class="job-header">
+          <div class="job-title">Backend Engineer — Ruby / Go</div>
+          <div class="job-period">Apr 2022 – May 2023</div>
+        </div>
+        <div class="job-company">freee Inc. · Tokyo, Japan</div>
+        <ul>
+          <li>Introduced Amazon ElastiCache for a high-load gRPC endpoint, reducing peak DB load from 90% to 10%</li>
+          <li>Improved Selenium workflow by caching browser profiles on AWS S3, raising sync success rate from 45% to 70%</li>
+          <li>Streamlined incident response by building reusable analysis queries and escalation criteria, shortening resolution cycle from 2 months to 2 weeks</li>
+          <li>Shipped e-commerce upload feature as emergency recovery, releasing in time for 1,000+ companies to file tax returns</li>
+        </ul>
+      </div>
+
+      <div class="job">
+        <div class="section-title" style="margin-bottom:2mm">Internships</div>
+        <div class="interns">
+          <div class="intern-item">
+            <div class="intern-title">AI / Software Engineer Intern</div>
+            <div class="intern-company">NABLAS Inc.</div>
+            <div class="intern-period">Sep 2020 – Mar 2021</div>
+            <div class="intern-detail">Added CV problem sets to PyGrade educational platform (WebAssembly/pyodide); deployed audio recognition AI on Azure, contributing to a closed deal</div>
+          </div>
+          <div class="intern-item">
+            <div class="intern-title">ML Engineer Intern</div>
+            <div class="intern-company">DMM Games</div>
+            <div class="intern-period">Feb 2020 – May 2020</div>
+            <div class="intern-detail">Redesigned data flow of a game recommendation system on GCP, reducing unnecessary scans and lowering infrastructure cost</div>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <div class="section">
+      <div class="section-title">Education</div>
+      <div class="edu-item">
+        <div class="edu-header">
+          <div class="edu-degree">MSc, Computer Science</div>
+          <div class="edu-period">Apr 2019 – Mar 2021</div>
+        </div>
+        <div class="edu-institution">Waseda University · Tokyo, Japan</div>
+        <div class="edu-detail">CNN architecture research · Managed 20+ GPU servers · Designed distributed experiment pipelines with PostgreSQL &amp; Redash</div>
+      </div>
+      <div class="edu-item">
+        <div class="edu-header">
+          <div class="edu-degree">International Student Exchange</div>
+          <div class="edu-period">Sep 2016 – Apr 2017</div>
+        </div>
+        <div class="edu-institution">University of Toronto Scarborough · Toronto, Canada</div>
+      </div>
+    </div>
+
+  </div>
+</div>
+</body>
+</html>


### PR DESCRIPTION
Adds `docs/resume.html` — a 1-page English resume targeting Google Cloud GenAI FDE position.\n\nAccessible at https://timtoronto634.github.io/resume.html after merge.