### PR TITLE
fix: revert job title to GTM Engineer, update pipeline bullet with Zoom RA

### DIFF
--- a/docs/resume.html
+++ b/docs/resume.html
@@ -264,7 +264,7 @@
   <!-- ── Sidebar ── -->
   <div class="sidebar">
     <h1>Atsuhiro<br>Uchida</h1>
-    <div class="subtitle">Internal FDE /<br>Software Engineer</div>
+    <div class="subtitle">AI Engineer /<br>Software Engineer</div>
 
     <div class="sidebar-section">
       <h2>Contact</h2>
@@ -337,12 +337,12 @@
 
       <div class="job">
         <div class="job-header">
-          <div class="job-title">Internal FDE (Forward Deployed Engineer)</div>
+          <div class="job-title">GTM Engineer | AI Engineer</div>
           <div class="job-period">May 2025 – Present</div>
         </div>
         <div class="job-company">Kaminashi Inc. · Tokyo, Japan</div>
         <ul>
-          <li>Built an AI pipeline integrating HubSpot CRM data with AWS Bedrock LLM API, cutting sales team promotion prep time by 60% and reducing proposal creation from 3 hours to 30 minutes</li>
+          <li>Built a multi-source AI pipeline aggregating HubSpot CRM and Zoom Revenue Accelerator data via REST APIs into AWS Bedrock LLM workflows, cutting sales team promotion prep time by 60% and reducing proposal creation from 3 hours to 30 minutes</li>
           <li>Rolled out Gemini-based AI workflows from an 8-person pilot to a 30-person sales org, delivering structured prompt templates and guardrails that enabled non-technical staff to self-serve without engineering support</li>
           <li>Identified high-impact AI use cases through stakeholder interviews, shipped iterative prototypes, and coached 30+ business users on AI-assisted workflows</li>
         </ul>

--- a/resume.html
+++ b/resume.html
@@ -264,7 +264,7 @@
   <!-- ── Sidebar ── -->
   <div class="sidebar">
     <h1>Atsuhiro<br>Uchida</h1>
-    <div class="subtitle">Internal FDE /<br>Software Engineer</div>
+    <div class="subtitle">AI Engineer /<br>Software Engineer</div>
 
     <div class="sidebar-section">
       <h2>Contact</h2>
@@ -337,12 +337,12 @@
 
       <div class="job">
         <div class="job-header">
-          <div class="job-title">Internal FDE (Forward Deployed Engineer)</div>
+          <div class="job-title">GTM Engineer | AI Engineer</div>
           <div class="job-period">May 2025 – Present</div>
         </div>
         <div class="job-company">Kaminashi Inc. · Tokyo, Japan</div>
         <ul>
-          <li>Built an AI pipeline integrating HubSpot CRM data with AWS Bedrock LLM API, cutting sales team promotion prep time by 60% and reducing proposal creation from 3 hours to 30 minutes</li>
+          <li>Built a multi-source AI pipeline aggregating HubSpot CRM and Zoom Revenue Accelerator data via REST APIs into AWS Bedrock LLM workflows, cutting sales team promotion prep time by 60% and reducing proposal creation from 3 hours to 30 minutes</li>
           <li>Rolled out Gemini-based AI workflows from an 8-person pilot to a 30-person sales org, delivering structured prompt templates and guardrails that enabled non-technical staff to self-serve without engineering support</li>
           <li>Identified high-impact AI use cases through stakeholder interviews, shipped iterative prototypes, and coached 30+ business users on AI-assisted workflows</li>
         </ul>


### PR DESCRIPTION
- Revert job title: Internal FDE → GTM Engineer | AI Engineer\n- Update pipeline bullet: add Zoom Revenue Accelerator as data source alongside HubSpot