### PR TITLE
fix: rewrite current role bullets with accurate scope and impact

### DIFF
--- a/docs/resume.html
+++ b/docs/resume.html
@@ -342,9 +342,9 @@
         </div>
         <div class="job-company">Kaminashi Inc. · Tokyo, Japan</div>
         <ul>
-          <li>Built a multi-source AI pipeline aggregating HubSpot CRM and Zoom Revenue Accelerator data via REST APIs into AWS Bedrock LLM workflows, cutting sales team promotion prep time by 60% and reducing proposal creation from 3 hours to 30 minutes</li>
-          <li>Rolled out Gemini-based AI workflows from an 8-person pilot to a 30-person sales org, delivering structured prompt templates and guardrails that enabled non-technical staff to self-serve without engineering support</li>
-          <li>Identified high-impact AI use cases through stakeholder interviews, shipped iterative prototypes, and coached 30+ business users on AI-assisted workflows</li>
+          <li>Conducted stakeholder interviews with sales reps to map field information needs, then built a pre-meeting briefing tool that auto-summarizes historical deal data, reducing first-meeting preparation time from 3 hours to 30 minutes</li>
+          <li>Architected a sales data platform integrating HubSpot CRM and Zoom Revenue Accelerator via REST APIs; enabled AI-driven meeting transcript analysis and automated reporting, cutting post-meeting documentation and follow-up material creation by 60%</li>
+          <li>Drove workflow automation by building Google Apps Script macros and Chrome extensions as low-cost alternatives to custom infrastructure; piloted tools with early adopters, then provided hands-on onboarding to drive adoption — applying a consistent build-vs-leverage framework based on user mindshare and incremental cost</li>
         </ul>
       </div>
 

--- a/resume.html
+++ b/resume.html
@@ -342,9 +342,9 @@
         </div>
         <div class="job-company">Kaminashi Inc. · Tokyo, Japan</div>
         <ul>
-          <li>Built a multi-source AI pipeline aggregating HubSpot CRM and Zoom Revenue Accelerator data via REST APIs into AWS Bedrock LLM workflows, cutting sales team promotion prep time by 60% and reducing proposal creation from 3 hours to 30 minutes</li>
-          <li>Rolled out Gemini-based AI workflows from an 8-person pilot to a 30-person sales org, delivering structured prompt templates and guardrails that enabled non-technical staff to self-serve without engineering support</li>
-          <li>Identified high-impact AI use cases through stakeholder interviews, shipped iterative prototypes, and coached 30+ business users on AI-assisted workflows</li>
+          <li>Conducted stakeholder interviews with sales reps to map field information needs, then built a pre-meeting briefing tool that auto-summarizes historical deal data, reducing first-meeting preparation time from 3 hours to 30 minutes</li>
+          <li>Architected a sales data platform integrating HubSpot CRM and Zoom Revenue Accelerator via REST APIs; enabled AI-driven meeting transcript analysis and automated reporting, cutting post-meeting documentation and follow-up material creation by 60%</li>
+          <li>Drove workflow automation by building Google Apps Script macros and Chrome extensions as low-cost alternatives to custom infrastructure; piloted tools with early adopters, then provided hands-on onboarding to drive adoption — applying a consistent build-vs-leverage framework based on user mindshare and incremental cost</li>
         </ul>
       </div>
 


### PR DESCRIPTION
Rewrites the 3 bullets for GTM Engineer | AI Engineer role:\n- ① Pre-meeting briefing tool (3h→30min)\n- ② Data platform with transcript analysis (60% post-meeting work reduction)\n- ③ GAS/Chrome extension automation with build-vs-leverage framework