### PR TITLE
fix: add Bedrock to bullet 1, strengthen bullet 3, add skills line

### DIFF
--- a/docs/resume.html
+++ b/docs/resume.html
@@ -285,9 +285,9 @@
       </div>
       <div class="job-company">Kaminashi Inc. · Tokyo, Japan</div>
       <ul>
-        <li>Conducted stakeholder interviews with sales reps to map field information needs, then built a pre-meeting briefing tool that auto-summarizes historical deal data — reducing first-meeting preparation time from 30 to 10 minutes while improving the quality and coverage of pre-call research</li>
+        <li>Conducted stakeholder interviews with sales reps to map field information needs, then built a pre-meeting briefing tool powered by AWS Bedrock LLM API that auto-summarizes historical deal data — reducing first-meeting preparation time from 30 to 10 minutes while improving the quality and coverage of pre-call research</li>
         <li>Architected a sales data platform integrating HubSpot CRM and Zoom Revenue Accelerator via REST APIs; enabled AI-driven meeting transcript analysis and automated reporting, cutting post-meeting documentation and follow-up material creation by 60%</li>
-        <li>Drove workflow automation by building Google Apps Script macros and Chrome extensions as low-cost alternatives to custom infrastructure; piloted tools with early adopters, then provided hands-on onboarding to drive adoption — applying a consistent build-vs-leverage framework based on user mindshare and incremental cost</li>
+        <li>As the sole AI engineer, designed and shipped automation tools (Google Apps Script, Chrome extensions, LLM integrations) by deliberately choosing low-maintenance solutions over custom infrastructure — maximizing impact per headcount while driving adoption through direct onboarding with end users</li>
       </ul>
     </div>
 
@@ -362,6 +362,12 @@
     </div>
   </div>
 
+
+  <!-- ── Skills ── -->
+  <div style="margin-top:4mm; padding-top:2mm; border-top:1px solid #1e3a5f; font-size:8pt; color:#444;">
+    <strong style="color:#1e3a5f; text-transform:uppercase; letter-spacing:0.08em; font-size:7.5pt;">Skills</strong>&ensp;
+    Python · Go · TypeScript · AWS Bedrock · HubSpot API · Google Cloud · Docker · Terraform · Claude
+  </div>
 
 </div>
 </body>

--- a/resume.html
+++ b/resume.html
@@ -285,9 +285,9 @@
       </div>
       <div class="job-company">Kaminashi Inc. · Tokyo, Japan</div>
       <ul>
-        <li>Conducted stakeholder interviews with sales reps to map field information needs, then built a pre-meeting briefing tool that auto-summarizes historical deal data — reducing first-meeting preparation time from 30 to 10 minutes while improving the quality and coverage of pre-call research</li>
+        <li>Conducted stakeholder interviews with sales reps to map field information needs, then built a pre-meeting briefing tool powered by AWS Bedrock LLM API that auto-summarizes historical deal data — reducing first-meeting preparation time from 30 to 10 minutes while improving the quality and coverage of pre-call research</li>
         <li>Architected a sales data platform integrating HubSpot CRM and Zoom Revenue Accelerator via REST APIs; enabled AI-driven meeting transcript analysis and automated reporting, cutting post-meeting documentation and follow-up material creation by 60%</li>
-        <li>Drove workflow automation by building Google Apps Script macros and Chrome extensions as low-cost alternatives to custom infrastructure; piloted tools with early adopters, then provided hands-on onboarding to drive adoption — applying a consistent build-vs-leverage framework based on user mindshare and incremental cost</li>
+        <li>As the sole AI engineer, designed and shipped automation tools (Google Apps Script, Chrome extensions, LLM integrations) by deliberately choosing low-maintenance solutions over custom infrastructure — maximizing impact per headcount while driving adoption through direct onboarding with end users</li>
       </ul>
     </div>
 
@@ -362,6 +362,12 @@
     </div>
   </div>
 
+
+  <!-- ── Skills ── -->
+  <div style="margin-top:4mm; padding-top:2mm; border-top:1px solid #1e3a5f; font-size:8pt; color:#444;">
+    <strong style="color:#1e3a5f; text-transform:uppercase; letter-spacing:0.08em; font-size:7.5pt;">Skills</strong>&ensp;
+    Python · Go · TypeScript · AWS Bedrock · HubSpot API · Google Cloud · Docker · Terraform · Claude
+  </div>
 
 </div>
 </body>


### PR DESCRIPTION
- Bullet 1: add 'powered by AWS Bedrock LLM API'\n- Bullet 3: rewrite as sole AI engineer framing with deliberate tech choices\n- Add 1-line skills footer: Python · Go · TypeScript · AWS Bedrock · HubSpot API · Google Cloud · Docker · Terraform · Claude