### PR TITLE
feat: add FDE summary, quantified metrics, community and languages

### DIFF
--- a/docs/resume.html
+++ b/docs/resume.html
@@ -18,14 +18,14 @@
       width: 210mm;
       min-height: 297mm;
       margin: 0 auto;
-      padding: 10mm 13mm 10mm 13mm;
+      padding: 8mm 13mm 6mm 13mm;
     }
 
     /* ── Header ── */
     .header {
       border-bottom: 2px solid #1e3a5f;
-      padding-bottom: 4mm;
-      margin-bottom: 5mm;
+      padding-bottom: 3mm;
+      margin-bottom: 4mm;
     }
 
     .header-top {
@@ -63,13 +63,13 @@
     .summary {
       font-size: 8.5pt;
       color: #333;
-      line-height: 1.5;
-      margin-bottom: 5mm;
+      line-height: 1.45;
+      margin-bottom: 4mm;
     }
 
     /* ── Sections ── */
     .section {
-      margin-bottom: 5mm;
+      margin-bottom: 4mm;
     }
 
     .section-title {
@@ -80,12 +80,12 @@
       color: #1e3a5f;
       border-bottom: 1px solid #1e3a5f;
       padding-bottom: 1mm;
-      margin-bottom: 3mm;
+      margin-bottom: 2.5mm;
     }
 
     /* ── Job entries ── */
     .job {
-      margin-bottom: 4mm;
+      margin-bottom: 3mm;
     }
 
     .job-header {
@@ -121,10 +121,10 @@
     .job ul li {
       font-size: 8.5pt;
       color: #222;
-      margin-bottom: 1.2mm;
+      margin-bottom: 1mm;
       padding-left: 4mm;
       position: relative;
-      line-height: 1.4;
+      line-height: 1.35;
     }
 
     .job ul li::before {
@@ -185,7 +185,7 @@
 
     /* ── Education ── */
     .edu-item {
-      margin-bottom: 2.5mm;
+      margin-bottom: 2mm;
     }
 
     .edu-header {
@@ -377,15 +377,15 @@
 
 
   <!-- ── Skills / Community / Languages ── -->
-  <div style="margin-top:4mm; padding-top:2mm; border-top:1px solid #1e3a5f; font-size:8pt; color:#444;">
+  <div style="margin-top:3mm; padding-top:2mm; border-top:1px solid #1e3a5f; font-size:8pt; color:#444;">
     <strong style="color:#1e3a5f; text-transform:uppercase; letter-spacing:0.08em; font-size:7.5pt;">Skills</strong>&ensp;
     Python · Go · TypeScript · LLM APIs (AWS Bedrock, Claude) · AWS / Google Cloud · HubSpot API · Docker · Terraform
   </div>
-  <div style="margin-top:1.5mm; font-size:8pt; color:#444;">
+  <div style="margin-top:1mm; font-size:8pt; color:#444;">
     <strong style="color:#1e3a5f; text-transform:uppercase; letter-spacing:0.08em; font-size:7.5pt;">Community</strong>&ensp;
     AWS Community Builder (2025–2026) · AWS re:Invent 2023 &amp; 2024 · Go Conference Japan 2024 &amp; 2025 (Volunteer)
   </div>
-  <div style="margin-top:1.5mm; font-size:8pt; color:#444;">
+  <div style="margin-top:1mm; font-size:8pt; color:#444;">
     <strong style="color:#1e3a5f; text-transform:uppercase; letter-spacing:0.08em; font-size:7.5pt;">Languages</strong>&ensp;
     Japanese (native) · English (business)
   </div>

--- a/docs/resume.html
+++ b/docs/resume.html
@@ -59,6 +59,14 @@
       text-decoration: none;
     }
 
+    /* ── Summary ── */
+    .summary {
+      font-size: 8.5pt;
+      color: #333;
+      line-height: 1.5;
+      margin-bottom: 5mm;
+    }
+
     /* ── Sections ── */
     .section {
       margin-bottom: 5mm;
@@ -274,6 +282,11 @@
     </div>
   </div>
 
+  <!-- ── Summary ── -->
+  <div class="summary">
+    AI engineer who ships LLM-powered tools end-to-end — from field interviews with sales reps and factory-floor visits to production deployment and user onboarding. Five years of backend/fullstack engineering (Go, TypeScript, Ruby) underpin rapid AI prototyping as the sole AI engineer embedded in a sales organization.
+  </div>
+
   <!-- ── Work Experience ── -->
   <div class="section">
     <div class="section-title">Work Experience</div>
@@ -285,9 +298,10 @@
       </div>
       <div class="job-company">Kaminashi Inc. · Tokyo, Japan</div>
       <ul>
-        <li>Conducted stakeholder interviews with sales reps to map field information needs, then built a pre-meeting briefing tool powered by AWS Bedrock LLM API that auto-summarizes historical deal data — reducing first-meeting preparation time from 30 to 10 minutes while improving the quality and coverage of pre-call research</li>
+        <li>Conducted stakeholder interviews with sales reps to map field information needs, then built a pre-meeting briefing tool powered by AWS Bedrock LLM API that auto-summarizes historical deal data — cutting first-meeting prep from 30 to 10 minutes and reclaiming 100+ hours/month across a 25-rep field sales team</li>
         <li>Architected a sales data platform integrating HubSpot CRM and Zoom Revenue Accelerator via REST APIs; enabled AI-driven meeting transcript analysis and automated reporting, cutting post-meeting documentation and follow-up material creation by 60%</li>
-        <li>As the sole AI engineer, designed and shipped automation tools (Google Apps Script, Chrome extensions, LLM integrations) by deliberately choosing low-maintenance solutions over custom infrastructure — maximizing impact per headcount while driving adoption through direct onboarding with end users</li>
+        <li>Built an LLM-powered handoff-memo generator for inside sales, replacing 15 minutes of daily manual writing per rep — saving the 10-person team ~50 hours/month</li>
+        <li>As the sole AI engineer embedded in the sales organization, designed and shipped automation tools (Google Apps Script, Chrome extensions, LLM integrations), deliberately choosing low-maintenance solutions over custom infrastructure — built in as little as one day, in reps' hands the following week, adopted by 20+ sales reps through direct onboarding</li>
       </ul>
     </div>
 
@@ -298,8 +312,7 @@
       </div>
       <div class="job-company">Kaminashi Inc. · Tokyo, Japan</div>
       <ul>
-        <li>Led end-to-end development of new products — from system design and infrastructure setup to backend implementation — while working with stakeholders to define minimum viable scope and accelerate time-to-delivery</li>
-        <li>Eliminated delivery bottlenecks by automating CI/CD pipelines and introducing code generation tooling, consistently reducing build and release cycle times</li>
+        <li>Led 0→1 development of Kaminashi Employee, an HR management product for frontline workers — from system design and infrastructure setup to backend implementation — while working with stakeholders to define minimum viable scope and accelerate time-to-delivery</li>
         <li>Implemented OIDC-compliant authentication flows across two services: client-side authorization and resource-server token validation, enabling secure cross-service access</li>
         <li>Partnered with a PM on factory-floor visits to interview site managers and frontline workers, directly observing operations to surface pain points invisible in stakeholder interviews — translated root-cause findings into product features rather than building to spec</li>
       </ul>
@@ -308,7 +321,7 @@
     <div class="job">
       <div class="job-header">
         <div class="job-title">Backend Engineer — Ruby / Go</div>
-        <div class="job-period">Apr 2022 – May 2023</div>
+        <div class="job-period">Apr 2021 – May 2023</div>
       </div>
       <div class="job-company">freee Inc. · Tokyo, Japan</div>
       <ul>
@@ -363,10 +376,18 @@
   </div>
 
 
-  <!-- ── Skills ── -->
+  <!-- ── Skills / Community / Languages ── -->
   <div style="margin-top:4mm; padding-top:2mm; border-top:1px solid #1e3a5f; font-size:8pt; color:#444;">
     <strong style="color:#1e3a5f; text-transform:uppercase; letter-spacing:0.08em; font-size:7.5pt;">Skills</strong>&ensp;
-    Python · Go · TypeScript · AWS Bedrock · HubSpot API · Google Cloud · Docker · Terraform · Claude
+    Python · Go · TypeScript · LLM APIs (AWS Bedrock, Claude) · AWS / Google Cloud · HubSpot API · Docker · Terraform
+  </div>
+  <div style="margin-top:1.5mm; font-size:8pt; color:#444;">
+    <strong style="color:#1e3a5f; text-transform:uppercase; letter-spacing:0.08em; font-size:7.5pt;">Community</strong>&ensp;
+    AWS Community Builder (2025–2026) · AWS re:Invent 2023 &amp; 2024 · Go Conference Japan 2024 &amp; 2025 (Volunteer)
+  </div>
+  <div style="margin-top:1.5mm; font-size:8pt; color:#444;">
+    <strong style="color:#1e3a5f; text-transform:uppercase; letter-spacing:0.08em; font-size:7.5pt;">Languages</strong>&ensp;
+    Japanese (native) · English (business)
   </div>
 
 </div>

--- a/resume.html
+++ b/resume.html
@@ -18,14 +18,14 @@
       width: 210mm;
       min-height: 297mm;
       margin: 0 auto;
-      padding: 10mm 13mm 10mm 13mm;
+      padding: 8mm 13mm 6mm 13mm;
     }
 
     /* ── Header ── */
     .header {
       border-bottom: 2px solid #1e3a5f;
-      padding-bottom: 4mm;
-      margin-bottom: 5mm;
+      padding-bottom: 3mm;
+      margin-bottom: 4mm;
     }
 
     .header-top {
@@ -63,13 +63,13 @@
     .summary {
       font-size: 8.5pt;
       color: #333;
-      line-height: 1.5;
-      margin-bottom: 5mm;
+      line-height: 1.45;
+      margin-bottom: 4mm;
     }
 
     /* ── Sections ── */
     .section {
-      margin-bottom: 5mm;
+      margin-bottom: 4mm;
     }
 
     .section-title {
@@ -80,12 +80,12 @@
       color: #1e3a5f;
       border-bottom: 1px solid #1e3a5f;
       padding-bottom: 1mm;
-      margin-bottom: 3mm;
+      margin-bottom: 2.5mm;
     }
 
     /* ── Job entries ── */
     .job {
-      margin-bottom: 4mm;
+      margin-bottom: 3mm;
     }
 
     .job-header {
@@ -121,10 +121,10 @@
     .job ul li {
       font-size: 8.5pt;
       color: #222;
-      margin-bottom: 1.2mm;
+      margin-bottom: 1mm;
       padding-left: 4mm;
       position: relative;
-      line-height: 1.4;
+      line-height: 1.35;
     }
 
     .job ul li::before {
@@ -185,7 +185,7 @@
 
     /* ── Education ── */
     .edu-item {
-      margin-bottom: 2.5mm;
+      margin-bottom: 2mm;
     }
 
     .edu-header {
@@ -377,15 +377,15 @@
 
 
   <!-- ── Skills / Community / Languages ── -->
-  <div style="margin-top:4mm; padding-top:2mm; border-top:1px solid #1e3a5f; font-size:8pt; color:#444;">
+  <div style="margin-top:3mm; padding-top:2mm; border-top:1px solid #1e3a5f; font-size:8pt; color:#444;">
     <strong style="color:#1e3a5f; text-transform:uppercase; letter-spacing:0.08em; font-size:7.5pt;">Skills</strong>&ensp;
     Python · Go · TypeScript · LLM APIs (AWS Bedrock, Claude) · AWS / Google Cloud · HubSpot API · Docker · Terraform
   </div>
-  <div style="margin-top:1.5mm; font-size:8pt; color:#444;">
+  <div style="margin-top:1mm; font-size:8pt; color:#444;">
     <strong style="color:#1e3a5f; text-transform:uppercase; letter-spacing:0.08em; font-size:7.5pt;">Community</strong>&ensp;
     AWS Community Builder (2025–2026) · AWS re:Invent 2023 &amp; 2024 · Go Conference Japan 2024 &amp; 2025 (Volunteer)
   </div>
-  <div style="margin-top:1.5mm; font-size:8pt; color:#444;">
+  <div style="margin-top:1mm; font-size:8pt; color:#444;">
     <strong style="color:#1e3a5f; text-transform:uppercase; letter-spacing:0.08em; font-size:7.5pt;">Languages</strong>&ensp;
     Japanese (native) · English (business)
   </div>

--- a/resume.html
+++ b/resume.html
@@ -59,6 +59,14 @@
       text-decoration: none;
     }
 
+    /* ── Summary ── */
+    .summary {
+      font-size: 8.5pt;
+      color: #333;
+      line-height: 1.5;
+      margin-bottom: 5mm;
+    }
+
     /* ── Sections ── */
     .section {
       margin-bottom: 5mm;
@@ -274,6 +282,11 @@
     </div>
   </div>
 
+  <!-- ── Summary ── -->
+  <div class="summary">
+    AI engineer who ships LLM-powered tools end-to-end — from field interviews with sales reps and factory-floor visits to production deployment and user onboarding. Five years of backend/fullstack engineering (Go, TypeScript, Ruby) underpin rapid AI prototyping as the sole AI engineer embedded in a sales organization.
+  </div>
+
   <!-- ── Work Experience ── -->
   <div class="section">
     <div class="section-title">Work Experience</div>
@@ -285,9 +298,10 @@
       </div>
       <div class="job-company">Kaminashi Inc. · Tokyo, Japan</div>
       <ul>
-        <li>Conducted stakeholder interviews with sales reps to map field information needs, then built a pre-meeting briefing tool powered by AWS Bedrock LLM API that auto-summarizes historical deal data — reducing first-meeting preparation time from 30 to 10 minutes while improving the quality and coverage of pre-call research</li>
+        <li>Conducted stakeholder interviews with sales reps to map field information needs, then built a pre-meeting briefing tool powered by AWS Bedrock LLM API that auto-summarizes historical deal data — cutting first-meeting prep from 30 to 10 minutes and reclaiming 100+ hours/month across a 25-rep field sales team</li>
         <li>Architected a sales data platform integrating HubSpot CRM and Zoom Revenue Accelerator via REST APIs; enabled AI-driven meeting transcript analysis and automated reporting, cutting post-meeting documentation and follow-up material creation by 60%</li>
-        <li>As the sole AI engineer, designed and shipped automation tools (Google Apps Script, Chrome extensions, LLM integrations) by deliberately choosing low-maintenance solutions over custom infrastructure — maximizing impact per headcount while driving adoption through direct onboarding with end users</li>
+        <li>Built an LLM-powered handoff-memo generator for inside sales, replacing 15 minutes of daily manual writing per rep — saving the 10-person team ~50 hours/month</li>
+        <li>As the sole AI engineer embedded in the sales organization, designed and shipped automation tools (Google Apps Script, Chrome extensions, LLM integrations), deliberately choosing low-maintenance solutions over custom infrastructure — built in as little as one day, in reps' hands the following week, adopted by 20+ sales reps through direct onboarding</li>
       </ul>
     </div>
 
@@ -298,8 +312,7 @@
       </div>
       <div class="job-company">Kaminashi Inc. · Tokyo, Japan</div>
       <ul>
-        <li>Led end-to-end development of new products — from system design and infrastructure setup to backend implementation — while working with stakeholders to define minimum viable scope and accelerate time-to-delivery</li>
-        <li>Eliminated delivery bottlenecks by automating CI/CD pipelines and introducing code generation tooling, consistently reducing build and release cycle times</li>
+        <li>Led 0→1 development of Kaminashi Employee, an HR management product for frontline workers — from system design and infrastructure setup to backend implementation — while working with stakeholders to define minimum viable scope and accelerate time-to-delivery</li>
         <li>Implemented OIDC-compliant authentication flows across two services: client-side authorization and resource-server token validation, enabling secure cross-service access</li>
         <li>Partnered with a PM on factory-floor visits to interview site managers and frontline workers, directly observing operations to surface pain points invisible in stakeholder interviews — translated root-cause findings into product features rather than building to spec</li>
       </ul>
@@ -308,7 +321,7 @@
     <div class="job">
       <div class="job-header">
         <div class="job-title">Backend Engineer — Ruby / Go</div>
-        <div class="job-period">Apr 2022 – May 2023</div>
+        <div class="job-period">Apr 2021 – May 2023</div>
       </div>
       <div class="job-company">freee Inc. · Tokyo, Japan</div>
       <ul>
@@ -363,10 +376,18 @@
   </div>
 
 
-  <!-- ── Skills ── -->
+  <!-- ── Skills / Community / Languages ── -->
   <div style="margin-top:4mm; padding-top:2mm; border-top:1px solid #1e3a5f; font-size:8pt; color:#444;">
     <strong style="color:#1e3a5f; text-transform:uppercase; letter-spacing:0.08em; font-size:7.5pt;">Skills</strong>&ensp;
-    Python · Go · TypeScript · AWS Bedrock · HubSpot API · Google Cloud · Docker · Terraform · Claude
+    Python · Go · TypeScript · LLM APIs (AWS Bedrock, Claude) · AWS / Google Cloud · HubSpot API · Docker · Terraform
+  </div>
+  <div style="margin-top:1.5mm; font-size:8pt; color:#444;">
+    <strong style="color:#1e3a5f; text-transform:uppercase; letter-spacing:0.08em; font-size:7.5pt;">Community</strong>&ensp;
+    AWS Community Builder (2025–2026) · AWS re:Invent 2023 &amp; 2024 · Go Conference Japan 2024 &amp; 2025 (Volunteer)
+  </div>
+  <div style="margin-top:1.5mm; font-size:8pt; color:#444;">
+    <strong style="color:#1e3a5f; text-transform:uppercase; letter-spacing:0.08em; font-size:7.5pt;">Languages</strong>&ensp;
+    Japanese (native) · English (business)
   </div>
 
 </div>


### PR DESCRIPTION
## Summary
- Add a 2-line FDE-oriented summary below the header (field interviews → production deployment story, 5 years of experience)
- Quantify current-role impact: briefing tool reclaims 100+ hours/month across a 25-rep field sales team; new bullet for the inside-sales handoff-memo generator (~50 hours/month); "embedded in the sales organization" framing with 1-day build / next-week adoption speed
- Fix freee start date (Apr 2021, was Apr 2022) and name Kaminashi Employee as the 0→1 product; drop the weak CI/CD bullet
- Restore Community as a compact one-liner, add Languages (Japanese native · English business), and consolidate skills into "LLM APIs (AWS Bedrock, Claude)" and "AWS / Google Cloud"

## Test plan
- [ ] Check the PDF preview generated by the resume-preview GitHub Action
- [ ] Confirm the resume still fits on a single A4 page
- [ ] Proofread the new summary and quantified bullets

🤖 Generated with [Claude Code](https://claude.com/claude-code)